### PR TITLE
Local port mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,6 @@ In order to use the SSO authentication your browser needs to talk to your app on
 
 You only need to do that once (well, maybe again if you upgrade your OS — that _might_ update your `hosts` file).
 
-In order to get your app to listen on port `80` you will need to make sure the following command is running *before every time* you run your node server:
-
-```sh
-$ sudo ssh -N -L 80:localhost:3001 `whoami`@localhost
-```
-
-Open up a new terminal window, run that command (you will be prompted for your password) and leave it running as you start up the application server, as described below.
-
 ## Running the Application
 
 ### Development Mode

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ In order to use the SSO authentication your browser needs to talk to your app on
 
 You only need to do that once (well, maybe again if you upgrade your OS — that _might_ update your `hosts` file).
 
-In order to get your app to listen on port `80` you will need to make sure the following command is running whenever you run your node server:
+In order to get your app to listen on port `80` you will need to make sure the following command is running *before every time* you run your node server:
 
 ```sh
 $ sudo ssh -N -L 80:localhost:3001 `whoami`@localhost
@@ -41,6 +41,12 @@ $ CLIENT_SECRET=[CLIENT_SECRET] npm start // Starts localhost:3001 defaulting to
 You can also set the `APP_ENV` variable which dictates what API environment to use as the main source.
 ```sh
 $ APP_ENV=development|qa|production CLIENT_SECRET=[CLIENT_SECRET] npm start // Starts localhost:3001 with set APP_ENV
+```
+
+If you do not have a default AWS profile on local instance, you MUST specify the AWS profile you'd like use with the app. To do so, you may include `AWS_PROFILE` on the command line
+
+```sh
+$ AWS_PROFILE=[AWS_PROFILE_NAME] APP_ENV=development|qa|production CLIENT_SECRET=[CLIENT_SECRET] npm start // Starts localhost:3001 with set APP_ENV
 ```
 
 ### Production Mode

--- a/config/appConfig.js
+++ b/config/appConfig.js
@@ -14,7 +14,7 @@ export default {
     loginUrl: process.env.OAUTH_LOGIN_URL || 'https://isso.nypl.org/auth/login',
     clientId: process.env.CLIENT_ID || 'platform_admin',
     clientSecret: process.env.CLIENT_SECRET,
-    callbackUrl: process.env.NODE_ENV === 'production' ? process.env.OAUTH_CALLBACK_URL : 'http://local.nypl.org/callback',
+    callbackUrl: process.env.NODE_ENV === 'production' ? process.env.OAUTH_CALLBACK_URL : 'http://local.nypl.org:3001/callback',
   },
   sqs: {
     region: process.env.AWS_REGION || 'us-east-1',


### PR DESCRIPTION
For non-production environments, point to port 3001 permanently to avoid having to execute mapping at every start of the app.