### PR TITLE
Move SQS related config to .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,4 @@
 CLIENT_SECRET=The secret for sending to our OAuth server for logging in
-REFILE_REQUEST_SECRET=The secret for requesting NYPL platform APIs. Please be aware of the environment of the platform 
+REFILE_REQUEST_SECRET=The secret for requesting NYPL platform APIs. Please be aware of the environment of the platform
+SQS_REGION=The region where the AWS SQS service locates
+SQS_API=The URL of the AWS SQS service

--- a/config/appConfig.js
+++ b/config/appConfig.js
@@ -19,10 +19,6 @@ export default {
     refileRequestId: process.env.REFILE_REQUEST_ID || 'refile_request_service',
     // refileRequestSecret should be put in .env file
   },
-  sqs: {
-    region: process.env.AWS_REGION || 'us-east-1',
-    api: process.env.AWS_SQS_API_URL || 'https://sqs.us-east-1.amazonaws.com/224280085904/sierra-updates-for-scsb-development'
-  },
   publicKey:
     '-----BEGIN PUBLIC KEY-----\n' +
     'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA44ilHg/PxcJYsISHMRyo\n' +

--- a/server.js
+++ b/server.js
@@ -28,7 +28,7 @@ const viewsPath = path.resolve(rootPath, 'src/server/views');
 const isProduction = process.env.NODE_ENV === 'production';
 const { applicationPort, sqs, oauth, publicKey } = appConfig;
 // AWS SQS Configuration
-aws.config.update({ region: sqs.region });
+aws.config.update({ region: process.env.SQS_REGION });
 const sqsClient = new aws.SQS({ apiVersion: '2012-11-05' });
 
 /* Express Server Configurations

--- a/src/server/routes/api/index.js
+++ b/src/server/routes/api/index.js
@@ -67,7 +67,7 @@ function validateSqsData(params, type) {
 
 export function handleSqsDataProcessing(sqsClient, type) {
   return (req, res, next) => {
-    cconst api = process.env.SQS_API;
+    const api = process.env.SQS_API;
     const email = req.user.email;
     const params = {...req.body, email};
     const validatedSqsData = validateSqsData(params, type);

--- a/src/server/routes/api/index.js
+++ b/src/server/routes/api/index.js
@@ -3,6 +3,7 @@ import config from '../../../../config/appConfig';
 import NyplApiClient from '@nypl/nypl-data-api-client';
 // Read local .env file. The environment variables will be assigned with process.env in the beginning
 import dotEnv from 'dotenv';
+dotEnv.config();
 
 function constructApiHeaders(token = '') {
   return {
@@ -66,7 +67,7 @@ function validateSqsData(params, type) {
 
 export function handleSqsDataProcessing(sqsClient, type) {
   return (req, res, next) => {
-    const { api } = config.sqs;
+    const api = process.env.SQS_API;
     const params = req.body;
     const validatedSqsData = validateSqsData(params, type);
 
@@ -113,9 +114,6 @@ export function handleSqsDataProcessing(sqsClient, type) {
 }
 
 export function getRefileErrors(req, res, next) {
-  // Read local .env file. The environment variables will be assigned with process.env in the beginning
-  dotEnv.config();
-
   const client = new NyplApiClient({
     base_url: 'https://dev-platform.nypl.org/api/v0.1/',
     oauth_key: config.oauth.refileRequestId,


### PR DESCRIPTION
This PR moves SQS related config to .env file and also adds the instructions in .env.example.