### PR TITLE
Dynamic queries for refile errors

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,6 @@
 CLIENT_SECRET=The secret for sending to our OAuth server for logging in
 REFILE_REQUEST_SECRET=The secret for requesting NYPL platform APIs. Please be aware of the environment of the platform
+PLATFORM_BASE_URL=The base URL of the APIs of NYPL's microservices
+TOKEN_URL_FOR_NYPL_API_CLIENT=The URL to request the client token for making an API call together to NYPL's microservices
 SQS_REGION=The region where the AWS SQS service locates
 SQS_API=The URL of the AWS SQS service

--- a/config/appConfig.js
+++ b/config/appConfig.js
@@ -1,3 +1,7 @@
+// Read local .env file. The environment variables will be assigned with process.env in the beginning
+import dotEnv from 'dotenv';
+dotEnv.config();
+
 export default {
   appTitle: 'NYPL | ReCAP Admin',
   appName: 'NYPL ReCAP Admin',
@@ -13,11 +17,14 @@ export default {
     tokenUrl: process.env.OAUTH_TOKEN_URL || 'https://isso.nypl.org/oauth/token',
     loginUrl: process.env.OAUTH_LOGIN_URL || 'https://isso.nypl.org/auth/login',
     clientId: process.env.CLIENT_ID || 'platform_admin',
-    // clientSecret should be put in .env file
+    clientSecret: process.env.CLIENT_SECRET,
     callbackUrl: process.env.NODE_ENV === 'production' ? process.env.OAUTH_CALLBACK_URL : 'http://local.nypl.org:3001/callback',
-    tokenUrlForNyplApiClient: 'https://isso.nypl.org/',
+  },
+  nyplMicroService: {
+    tokenUrlForNyplApiClient: process.env.TOKEN_URL_FOR_NYPL_API_CLIENT,
+    platformBaseUrl: process.env.PLATFORM_BASE_URL,
     refileRequestId: process.env.REFILE_REQUEST_ID || 'refile_request_service',
-    // refileRequestSecret should be put in .env file
+    refileRequestSecret: process.env.REFILE_REQUEST_SECRET,
   },
   publicKey:
     '-----BEGIN PUBLIC KEY-----\n' +

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@nypl/design-toolkit": "0.1.33",
-    "@nypl/nypl-data-api-client": "0.2.5",
+    "@nypl/nypl-data-api-client": "1.0.0",
     "aws-sdk": "2.188.0",
     "axios": "0.14.0",
     "babel-core": "6.26.0",

--- a/src/server/routes/api/index.js
+++ b/src/server/routes/api/index.js
@@ -182,16 +182,16 @@ export function getRefileErrors(req, res, next) {
     }
   )
   .then(response => {
-    res.json({
-      status: 200,
-      count: limitQuery,
+    res.status(200)
+    .header('Content-Type', 'application/json')
+    .json({
       data: response
     });
   })
   .catch(error => {
-    res.json({
-      status: 400,
-      count: limitQuery,
+   res.status(500)
+    .header('Content-Type', 'application/json')
+    .json({
       data: error
     });
   });

--- a/src/server/routes/api/index.js
+++ b/src/server/routes/api/index.js
@@ -121,12 +121,11 @@ function constructDateQuery(dateInput, isEndDate = false) {
   if (dateInput && typeof dateInput === 'string') {
     const dateArray = dateInput.split('/');
 
-    // Checks if it has a valid date format
-    if (!dateArray || dateArray.length !== 3) {
-      return undefined;
-    }
+    // Checks if it has a valid date format. The Regex check if the inputs are digits
+    // and if they have right number of digits
+    const date_matches = dateInput.match(/^(\d{2})\/(\d{2})\/(?:\d{4})$/);
 
-    if (dateArray[0].length !== 2 || dateArray[1].length !== 2 || dateArray[2].length !== 4) {
+    if (!date_matches) {
       return undefined;
     }
 

--- a/src/server/routes/api/index.js
+++ b/src/server/routes/api/index.js
@@ -1,9 +1,6 @@
 import isEmpty from 'lodash/isEmpty';
 import config from '../../../../config/appConfig';
 import NyplApiClient from '@nypl/nypl-data-api-client';
-// Read local .env file. The environment variables will be assigned with process.env in the beginning
-import dotEnv from 'dotenv';
-dotEnv.config();
 
 function constructApiHeaders(token = '') {
   return {
@@ -171,14 +168,15 @@ export function getRefileErrors(req, res, next) {
   }
 
   const client = new NyplApiClient({
-    base_url: 'https://dev-platform.nypl.org/api/v0.1/',
-    oauth_key: config.oauth.refileRequestId,
-    oauth_secret: process.env.REFILE_REQUEST_SECRET,
-    oauth_url: config.oauth.tokenUrlForNyplApiClient,
+    base_url: config.nyplMicroService.platformBaseUrl,
+    oauth_key: config.nyplMicroService.refileRequestId,
+    oauth_secret: config.nyplMicroService.refileRequestSecret,
+    oauth_url: config.nyplMicroService.tokenUrlForNyplApiClient,
   });
 
   client.get(
-    `recap/refile-requests?createdDate=[${startDateQuery},${endDateQuery}]&offset=${offsetQuery}&limit=${limitQuery}&includeTotalCount=true`,
+    `recap/refile-requests?createdDate=[${startDateQuery},${endDateQuery}]`+
+    `&offset=${offsetQuery}&limit=${limitQuery}&includeTotalCount=true`,
     {
       json: true,
     }

--- a/src/server/routes/api/index.js
+++ b/src/server/routes/api/index.js
@@ -114,6 +114,13 @@ export function handleSqsDataProcessing(sqsClient, type) {
 }
 
 export function getRefileErrors(req, res, next) {
+    // The format of start date and end date should be YYYY-MM-DD
+    const startDateQuery = req.body.startDate.replace(/\//g, '-');
+    const endDateQuery = req.body.endDate.replace(/\//g, '-');
+    const offsetQuery = req.body.offset;
+    const limitQuery = 25;
+
+
   const client = new NyplApiClient({
     base_url: 'https://dev-platform.nypl.org/api/v0.1/',
     oauth_key: config.oauth.refileRequestId,
@@ -122,7 +129,7 @@ export function getRefileErrors(req, res, next) {
   });
 
   client.get(
-    'recap/refile-requests?createdDate=[2018-02-01,2018-03-03]&offset=0&limit=25',
+    `recap/refile-requests?createdDate=[${startDateQuery},${endDateQuery}]&offset=${offsetQuery}&limit=${limitQuery}`,
     {
       json: true,
     }

--- a/src/server/routes/api/index.js
+++ b/src/server/routes/api/index.js
@@ -114,6 +114,10 @@ export function handleSqsDataProcessing(sqsClient, type) {
   };
 }
 
+/**
+* constructDateQuery(dateInput, isEndDate = false)
+* @desc Builds the queries of the dates for sending to the API
+*/
 function constructDateQuery(dateInput, isEndDate = false) {
   const lastSecond = (isEndDate) ? 'T23:59:59' : '';
 
@@ -156,6 +160,15 @@ export function getRefileErrors(req, res, next) {
   const endDateQuery = constructDateQuery(req.body.endDate, true);
   const offsetQuery = req.body.offset;
   const limitQuery = 25;
+
+  // For the case the date inputs are not valid format or value
+  if (!startDateQuery || !endDateQuery) {
+    res.status(400)
+    .header('Content-Type', 'application/json')
+    .json({
+      message: 'Not valid date inputs.'
+    });
+  }
 
   const client = new NyplApiClient({
     base_url: 'https://dev-platform.nypl.org/api/v0.1/',

--- a/src/shared/containers/Refile/RefileErrorsForm.jsx
+++ b/src/shared/containers/Refile/RefileErrorsForm.jsx
@@ -144,7 +144,7 @@ class RefileErrorsForm extends Component {
       // Update the Parent Container Loading State
       this.props.setApplicationLoadingState(true);
 
-      // The format of start date and end date should be YYYY/MM/DD
+      // The format of start date and end date should be MM/DD/YYYY
       return axios.post(
         '/get-refile-errors',
         {

--- a/src/shared/containers/Refile/RefileErrorsForm.jsx
+++ b/src/shared/containers/Refile/RefileErrorsForm.jsx
@@ -12,6 +12,7 @@ class RefileErrorsForm extends Component {
       formFields: {
         startDate: '',
         endDate: '',
+        offset: 0,
       },
       fieldErrors: {},
       formResult: {}
@@ -136,20 +137,20 @@ class RefileErrorsForm extends Component {
         formFields: {
           startDate,
           endDate,
+          offset,
         }
       } = this.state;
 
       // Update the Parent Container Loading State
       this.props.setApplicationLoadingState(true);
 
+      // The format of start date and end date should be YYYY/MM/DD
       return axios.post(
         '/get-refile-errors',
         {
           startDate,
           endDate,
-        },
-        {
-          headers: { 'csrf-token': this.state.csrfToken }
+          offset,
         }
       ).then(response => {
         console.log('Form Successful Response: ', response);


### PR DESCRIPTION
This PR is to set up the functions to make API calls to NYPL's refile error endpoint. It integrates `nypl-data-api-client` to get the NYPL platform token and make the calls.

This PR also moves the configurations to `.env` file and adds the `.env.example` as an reference.