### PR TITLE
Integrating with toolkit

### DIFF
--- a/config/appConfig.js
+++ b/config/appConfig.js
@@ -22,7 +22,7 @@ export default {
   },
   nyplMicroService: {
     tokenUrlForNyplApiClient: process.env.TOKEN_URL_FOR_NYPL_API_CLIENT,
-    platformBaseUrl: process.env.NODE_ENV === 'production' ? process.env.PLATFORM_BASE_URL : process.env.DEV_PLATFORM_BASE_URL,
+    platformBaseUrl: process.env.APP_ENV === 'production' ? process.env.PLATFORM_BASE_URL : process.env.DEV_PLATFORM_BASE_URL,
     refileRequestId: process.env.REFILE_REQUEST_ID || 'refile_request_service',
     refileRequestSecret: process.env.REFILE_REQUEST_SECRET,
   },

--- a/src/client/styles/containers/_refile.scss
+++ b/src/client/styles/containers/_refile.scss
@@ -1,0 +1,50 @@
+.date-divider {
+  display: inline-block;
+  margin: 20px;
+  float: left;
+  padding-top: 16px;
+  @media (max-width: 965px) {
+    float: none;
+    padding-top: 0;
+  }
+}
+
+.recap-admin-date-field.recap-admin-date-field {
+  width: calc(50% - 30px);
+  @media (max-width: 965px) {
+    width: auto;
+  }
+}
+
+.pointer {
+  cursor: pointer;
+}
+
+.result-table {
+  border-collapse: collapse;
+  width: 100%;
+
+  thead {
+    background-color: #D7D4D0;
+  }
+
+  td, th {
+    border-color: #D7D4D0;
+    border-style: solid;
+    border-width: 1px;
+  }
+
+  td {
+    margin: 0 2px;
+    text-align: center;
+  }
+
+  .barcode-th {
+    text-align: left;
+    padding-left: 20px;
+  }
+}
+
+.display-result-text {
+  margin-top: 20px;
+}

--- a/src/client/styles/main.scss
+++ b/src/client/styles/main.scss
@@ -5,6 +5,7 @@
 // App Components
 @import 'components/loader';
 @import 'components/sidebar-navigation';
+@import 'containers/refile';
 
 .app-header {
   background-color: $nypl-blue-tint;
@@ -37,55 +38,4 @@
       width: 5rem;
     }
   }
-}
-
-.date-divider {
-  display: inline-block;
-  margin: 20px;
-  float: left;
-  padding-top: 16px;
-  @media (max-width: 965px) {
-    float: none;
-    padding-top: 0;
-  }
-}
-
-.recap-admin-date-field.recap-admin-date-field {
-  width: calc(50% - 30px);
-  @media (max-width: 965px) {
-    width: auto;
-  }
-}
-
-.pointer {
-  cursor: pointer;
-}
-
-.result-table {
-  border-collapse: collapse;
-  width: 100%;
-
-  thead {
-    background-color: #D7D4D0;
-  }
-
-  td, th {
-    border-color: #D7D4D0;
-    border-style: solid;
-    border-width: 1px;
-  }
-
-  td {
-    margin: 0 2px;
-    text-align: center;
-  }
-
-  .barcode-th {
-    text-align: left;
-    padding-left: 20px;
-  }
-}
-
-.display-result-text {
-  margin-top: 20px;
 }

--- a/src/client/styles/main.scss
+++ b/src/client/styles/main.scss
@@ -38,3 +38,21 @@
     }
   }
 }
+
+.date-divider {
+  display: inline-block;
+  margin: 20px;
+  float: left;
+  padding-top: 16px;
+  @media (max-width: 965px) {
+    float: none;
+    padding-top: 0;
+  }
+}
+
+.recap-admin-date-field.recap-admin-date-field {
+  width: calc(50% - 30px);
+  @media (max-width: 965px) {
+    width: auto;
+  }
+}

--- a/src/client/styles/main.scss
+++ b/src/client/styles/main.scss
@@ -60,3 +60,28 @@
 .pointer {
   cursor: pointer;
 }
+
+.result-table {
+  border-collapse: collapse;
+  width: 100%;
+
+  thead {
+    background-color: #D7D4D0;
+  }
+
+  td, th {
+    border-color: #D7D4D0;
+    border-style: solid;
+    border-width: 1px;
+  }
+
+  td {
+    margin: 0 2px;
+    text-align: center;
+  }
+
+  .barcode-th {
+    text-align: left;
+    padding-left: 20px;
+  }
+}

--- a/src/client/styles/main.scss
+++ b/src/client/styles/main.scss
@@ -85,3 +85,7 @@
     padding-left: 20px;
   }
 }
+
+.display-result-text {
+  margin-top: 20px;
+}

--- a/src/client/styles/main.scss
+++ b/src/client/styles/main.scss
@@ -56,3 +56,7 @@
     width: auto;
   }
 }
+
+.pointer {
+  cursor: pointer;
+}

--- a/src/server/routes/api/index.js
+++ b/src/server/routes/api/index.js
@@ -120,8 +120,8 @@ function constructDateQuery(dateInput, isEndDate = false) {
 
   if (dateInput && typeof dateInput === 'string') {
     const dateArray = dateInput.split('-');
-    const month = parseInt(dateArray[0], 10);
-    const date = parseInt(dateArray[1], 10);
+    const month = parseInt(dateArray[1], 10);
+    const date = parseInt(dateArray[2], 10);
 
     // Checks if it has a valid date format. The Regex check if the inputs are digits
     // and if they have right number of digits

--- a/src/server/routes/api/index.js
+++ b/src/server/routes/api/index.js
@@ -119,27 +119,27 @@ function constructDateQuery(dateInput, isEndDate = false) {
   const lastSecond = (isEndDate) ? 'T23:59:59' : '';
 
   if (dateInput && typeof dateInput === 'string') {
-    const dateArray = dateInput.split('/');
+    const dateArray = dateInput.split('-');
 
     // Checks if it has a valid date format. The Regex check if the inputs are digits
     // and if they have right number of digits
-    const date_matches = dateInput.match(/^(\d{2})\/(\d{2})\/(?:\d{4})$/);
+    const date_matches = dateInput.match(/^(\d{4})\-(\d{2})\-(?:\d{2})$/);
 
     if (!date_matches) {
       return undefined;
     }
 
     // Checks if the month is valid
-    if (parseInt(dateArray[0], 10) < 1 || parseInt(dateArray[0], 10) > 12) {
+    if (parseInt(dateArray[1], 10) < 1 || parseInt(dateArray[1], 10) > 12) {
       return undefined;
     }
 
     // Checks if the date is valid
-    if (parseInt(dateArray[1], 10) < 1 || parseInt(dateArray[1], 10) > 31) {
+    if (parseInt(dateArray[2], 10) < 1 || parseInt(dateArray[2], 10) > 31) {
       return undefined;
     }
 
-    return `${dateArray[2]}-${dateArray[0]}-${dateArray[1]}${lastSecond}`;
+    return `${dateArray[0]}-${dateArray[1]}-${dateArray[2]}${lastSecond}`;
   }
 
   return undefined;

--- a/src/shared/containers/Refile/RefileErrorsForm.jsx
+++ b/src/shared/containers/Refile/RefileErrorsForm.jsx
@@ -30,7 +30,7 @@ class RefileErrorsForm extends Component {
     this.handleInputChange = this.handleInputChange.bind(this);
     this.handleFormSubmit = this.handleFormSubmit.bind(this);
     this.clickSubmit = this.clickSubmit.bind(this);
-    this.hitPageButton = this.hitPageButton.bind(this);
+    this.hitPageLink = this.hitPageLink.bind(this);
   }
 
   componentDidMount() {
@@ -164,13 +164,11 @@ class RefileErrorsForm extends Component {
   * handleFormSubmit()
   * @param {string} type - indicates if it is previous button or next button has been clicked
   */
-  hitPageButton(type) {
+  hitPageLink(type) {
     event.preventDefault();
 
     const resultLimit = this.state.formFields.resultLimit;
     const pageIncrement = 1;
-    const offsetInt = parseInt(this.state.formFields.offset, 10);
-
     // Set new state values based on the results from the new request
     const setStateForPagination = () => {
       const pageDifference = (type === 'pre') ? -1 : 1;
@@ -188,16 +186,8 @@ class RefileErrorsForm extends Component {
     };
 
     if (type === 'pre') {
-      if (offsetInt <= 0) {
-        return;
-      }
-
       setStateForPagination();
     } else {
-      if (parseInt(this.state.refileErrorResultsTotal, 10) <= offsetInt + resultLimit) {
-        return;
-      }
-
       setStateForPagination();
     }
   }
@@ -286,43 +276,43 @@ class RefileErrorsForm extends Component {
   renderRefileErrorsFrom() {
     return (
       <form onSubmit={this.clickSubmit}>
-          <div className="nypl-name-field nypl-filter-date-field">
-            <FormField
-              id="startDate"
-              className="recap-admin-date-field"
-              type="date"
-              label="Start Date"
-              fieldName="startDate"
-              instructionText="The start date as the format as MM/DD/YYYY"
-              value={this.state.formFields.startDate}
-              handleOnChange={this.handleInputChange}
-              errorField={this.state.fieldErrors.startDate}
-              fieldRef={(input) => { this.startDate = input; }}
-              isRequired
-            />
-            <span className="date-divider">to</span>
-            <FormField
-              id="endDate"
-              className="recap-admin-date-field"
-              type="date"
-              label="End Date"
-              fieldName="endDate"
-              instructionText="The end date as the format as MM/DD/YYYY"
-              value={this.state.formFields.endDate}
-              handleOnChange={this.handleInputChange}
-              errorField={this.state.fieldErrors.endDate}
-              fieldRef={(input) => { this.endDate = input; }}
-              isRequired
-            />
-          </div>
-          <div className="nypl-submit-button-wrapper">
-            <input
-              className="nypl-primary-button"
-              type="submit"
-              value="Submit"
-              disabled={this.props.isFormProcessing}
-            />
-          </div>
+        <div className="nypl-name-field nypl-filter-date-field">
+          <FormField
+            id="startDate"
+            className="recap-admin-date-field"
+            type="date"
+            label="Start Date"
+            fieldName="startDate"
+            instructionText="The start date as the format as MM/DD/YYYY"
+            value={this.state.formFields.startDate}
+            handleOnChange={this.handleInputChange}
+            errorField={this.state.fieldErrors.startDate}
+            fieldRef={(input) => { this.startDate = input; }}
+            isRequired
+          />
+          <span className="date-divider">to</span>
+          <FormField
+            id="endDate"
+            className="recap-admin-date-field"
+            type="date"
+            label="End Date"
+            fieldName="endDate"
+            instructionText="The end date as the format as MM/DD/YYYY"
+            value={this.state.formFields.endDate}
+            handleOnChange={this.handleInputChange}
+            errorField={this.state.fieldErrors.endDate}
+            fieldRef={(input) => { this.endDate = input; }}
+            isRequired
+          />
+        </div>
+        <div className="nypl-submit-button-wrapper">
+          <input
+            className="nypl-primary-button"
+            type="submit"
+            value="Submit"
+            disabled={this.props.isFormProcessing}
+          />
+        </div>
       </form>
     );
   }
@@ -368,6 +358,51 @@ class RefileErrorsForm extends Component {
     return resultContent;
   }
 
+  /**
+  * @desc Renders the links to navigate through the pages of the results
+  * Based on the current page, if it is the first page, then there will not be the previous link.
+  * If it is the last page, then there will not be the next link.
+  */
+  renderPaginationLink(type) {
+    const offsetInt = parseInt(this.state.formFields.offset, 10);
+    const resultLimit = this.state.formFields.resultLimit;
+
+    if (this.state.refileErrorResults && this.state.refileErrorResults.length) {
+      if (type === 'pre') {
+        if (offsetInt <= 0) {
+          return;
+        }
+        return (
+          <a
+            className="previous-link pointer"
+            onClick={() => this.hitPageLink('pre')}
+            onKeyDown={() => this.hitPageLink('pre')}
+            role="link"
+            tabIndex="0"
+          >
+            Previous
+          </a>
+        );
+      }
+
+      if (parseInt(this.state.refileErrorResultsTotal, 10) <= offsetInt + resultLimit) {
+        return;
+      }
+      return (
+        <a
+          className="next-link pointer"
+          onClick={() => this.hitPageLink('next')}
+          onKeyDown={() => this.hitPageLink('next')}
+          role="link"
+          tabIndex="0"
+        >
+          Next
+        </a>
+      );
+    }
+    return;
+  }
+
   render() {
     const totalResultCount = this.state.refileErrorResultsTotal;
     const itemStart = parseInt(this.state.formFields.offset, 10) + 1;
@@ -379,11 +414,7 @@ class RefileErrorsForm extends Component {
       <p>Displaying {itemStart}-{itemEnd} of {totalResultCount} errors from {displayFields.startDate}-{displayFields.endDate}</p> :
       null;
     const pageText = (this.state.refileErrorResults && this.state.refileErrorResults.length) ?
-      <p>Page {currentPage} of {totalPageNumber}</p> : null;
-    const preButton = (this.state.refileErrorResults && this.state.refileErrorResults.length) ?
-      <button onClick={() => this.hitPageButton('pre')}>Previous</button> : null;
-    const nextButton = (this.state.refileErrorResults && this.state.refileErrorResults.length) ?
-      <button onClick={() => this.hitPageButton('next')}>Next</button> : null;
+      <span className="page-count">Page {currentPage} of {totalPageNumber}</span> : null;
 
     return (
       <div className={this.props.className} id={this.props.id}>
@@ -394,9 +425,11 @@ class RefileErrorsForm extends Component {
           {displayingText}
           {this.renderRefileErrorResults()}
         </div>
-        {preButton}
-        {pageText}
-        {nextButton}
+        <nav className="nypl-results-pagination">
+          {this.renderPaginationLink('pre')}
+          {pageText}
+          {this.renderPaginationLink('next')}
+        </nav>
       </div>
     );
   }

--- a/src/shared/containers/Refile/RefileErrorsForm.jsx
+++ b/src/shared/containers/Refile/RefileErrorsForm.jsx
@@ -332,14 +332,14 @@ class RefileErrorsForm extends Component {
       map(this.state.refileErrorResults, (item, i) =>
         <tr key={i}>
           <td>{item.id}</td>
-          <td>{item.itemBarcode}</td>
+          <th className="barcode-th">{item.itemBarcode}</th>
           <td>{(item.updatedDate) ? item.createdDate.split('T')[0] : ''}</td>
           <td>{(item.updatedDate) ? item.updatedDate.split('T')[0] : ''}</td>
         </tr>
       ) : null;
 
     resultContent = (itemRows) ? (
-      <table>
+      <table className="result-table">
         <caption className="hidden">Refile Error Details</caption>
         <thead>
           <tr>
@@ -349,7 +349,7 @@ class RefileErrorsForm extends Component {
             <th scope="col">Updated Date</th>
           </tr>
         </thead>
-        <tbody>
+        <tbody className="result-table-body">
           {itemRows}
         </tbody>
       </table>

--- a/src/shared/containers/Refile/RefileErrorsForm.jsx
+++ b/src/shared/containers/Refile/RefileErrorsForm.jsx
@@ -11,8 +11,8 @@ class RefileErrorsForm extends Component {
     super(props);
     this.state = {
       formFields: {
-        startDate: moment().subtract(1, 'day').format('MM/DD/YYYY'),
-        endDate: moment().format('MM/DD/YYYY'),
+        startDate: moment().subtract(1, 'day').format('YYYY-MM-DD'),
+        endDate: moment().format('YYYY-MM-DD'),
         offset: 0,
         resultLimit: 25,
       },
@@ -105,22 +105,22 @@ class RefileErrorsForm extends Component {
       return false;
     }
 
-    const dateArray = date.split('/');
+    const dateArray = date.split('-');
     // Checks if it has a valid date format. The Regex check if the inputs are digits
     // and if they have right number of digits
-    const dateMatches = date.match(/^(\d{2})\/(\d{2})\/(?:\d{4})$/);
+    const dateMatches = date.match(/^(\d{4})\-(\d{2})\-(?:\d{2})$/);
 
     if (!dateMatches) {
       return false;
     }
 
     // Checks if the month is valid
-    if (parseInt(dateArray[0], 10) < 1 || parseInt(dateArray[0], 10) > 12) {
+    if (parseInt(dateArray[1], 10) < 1 || parseInt(dateArray[1], 10) > 12) {
       return false;
     }
 
     // Checks if the date is valid
-    if (parseInt(dateArray[1], 10) < 1 || parseInt(dateArray[1], 10) > 31) {
+    if (parseInt(dateArray[2], 10) < 1 || parseInt(dateArray[2], 10) > 31) {
       return false;
     }
 
@@ -287,10 +287,10 @@ class RefileErrorsForm extends Component {
     return (
       <form onSubmit={this.clickSubmit}>
         <FormField
-          className="nypl-text-field"
+          className="nypl-date-field"
           id="startDate"
-          type="text"
-          label="StartDate"
+          type="date"
+          label="Start Date"
           fieldName="startDate"
           instructionText="The start date as the format as MM/DD/YYYY"
           value={this.state.formFields.startDate}
@@ -301,10 +301,10 @@ class RefileErrorsForm extends Component {
         />
         <span>to</span>
         <FormField
-          className="nypl-text-field"
+          className="nypl-date-field"
           id="endDate"
-          type="text"
-          label="EndDate"
+          type="date"
+          label="End Date"
           fieldName="endDate"
           instructionText="The end date as the format as MM/DD/YYYY"
           value={this.state.formFields.endDate}

--- a/src/shared/containers/Refile/RefileErrorsForm.jsx
+++ b/src/shared/containers/Refile/RefileErrorsForm.jsx
@@ -106,8 +106,8 @@ class RefileErrorsForm extends Component {
     }
 
     const dateArray = dateInput.split('-');
-    const month = parseInt(dateArray[0], 10);
-    const date = parseInt(dateArray[1], 10);
+    const month = parseInt(dateArray[1], 10);
+    const date = parseInt(dateArray[2], 10);
     // Checks if it has a valid date format. The Regex check if the inputs are digits
     // and if they have right number of digits
     const dateMatches = dateInput.match(/^(\d{4})\-(\d{2})\-(?:\d{2})$/);

--- a/src/shared/containers/Refile/RefileErrorsForm.jsx
+++ b/src/shared/containers/Refile/RefileErrorsForm.jsx
@@ -324,7 +324,7 @@ class RefileErrorsForm extends Component {
     let resultContent = '';
 
     if (this.state.formResult.response) {
-      resultContent = <p>The input dates have invalid format or value, please check again.</p>;
+      resultContent = <p className="display-result-text">The input dates have invalid format or value, please check again.</p>;
       return resultContent;
     }
 
@@ -353,7 +353,7 @@ class RefileErrorsForm extends Component {
           {itemRows}
         </tbody>
       </table>
-    ) : <p>There is no refile errors in the range of the selected dates.</p>;
+    ) : <p className="display-result-text">There is no refile errors in the range of the selected dates.</p>;
 
     return resultContent;
   }
@@ -411,7 +411,7 @@ class RefileErrorsForm extends Component {
     const totalPageNumber = Math.ceil((parseInt(totalResultCount, 10) / 25));
     const displayFields = this.state.displayFields;
     const displayingText = (this.state.refileErrorResults && this.state.refileErrorResults.length) ?
-      <p>Displaying {itemStart}-{itemEnd} of {totalResultCount} errors from {displayFields.startDate}-{displayFields.endDate}</p> :
+      <p className="display-result-text">Displaying {itemStart}-{itemEnd} of {totalResultCount} errors from {displayFields.startDate}-{displayFields.endDate}</p> :
       null;
     const pageText = (this.state.refileErrorResults && this.state.refileErrorResults.length) ?
       <span className="page-count">Page {currentPage} of {totalPageNumber}</span> : null;

--- a/src/shared/containers/Refile/RefileErrorsForm.jsx
+++ b/src/shared/containers/Refile/RefileErrorsForm.jsx
@@ -286,41 +286,43 @@ class RefileErrorsForm extends Component {
   renderRefileErrorsFrom() {
     return (
       <form onSubmit={this.clickSubmit}>
-        <FormField
-          className="nypl-date-field"
-          id="startDate"
-          type="date"
-          label="Start Date"
-          fieldName="startDate"
-          instructionText="The start date as the format as MM/DD/YYYY"
-          value={this.state.formFields.startDate}
-          handleOnChange={this.handleInputChange}
-          errorField={this.state.fieldErrors.startDate}
-          fieldRef={(input) => { this.startDate = input; }}
-          isRequired
-        />
-        <span>to</span>
-        <FormField
-          className="nypl-date-field"
-          id="endDate"
-          type="date"
-          label="End Date"
-          fieldName="endDate"
-          instructionText="The end date as the format as MM/DD/YYYY"
-          value={this.state.formFields.endDate}
-          handleOnChange={this.handleInputChange}
-          errorField={this.state.fieldErrors.endDate}
-          fieldRef={(input) => { this.endDate = input; }}
-          isRequired
-        />
-        <div className="nypl-submit-button-wrapper">
-          <input
-            className="nypl-primary-button"
-            type="submit"
-            value="Submit"
-            disabled={this.props.isFormProcessing}
-          />
-        </div>
+          <div className="nypl-name-field nypl-filter-date-field">
+            <FormField
+              id="startDate"
+              className="recap-admin-date-field"
+              type="date"
+              label="Start Date"
+              fieldName="startDate"
+              instructionText="The start date as the format as MM/DD/YYYY"
+              value={this.state.formFields.startDate}
+              handleOnChange={this.handleInputChange}
+              errorField={this.state.fieldErrors.startDate}
+              fieldRef={(input) => { this.startDate = input; }}
+              isRequired
+            />
+            <span className="date-divider">to</span>
+            <FormField
+              id="endDate"
+              className="recap-admin-date-field"
+              type="date"
+              label="End Date"
+              fieldName="endDate"
+              instructionText="The end date as the format as MM/DD/YYYY"
+              value={this.state.formFields.endDate}
+              handleOnChange={this.handleInputChange}
+              errorField={this.state.fieldErrors.endDate}
+              fieldRef={(input) => { this.endDate = input; }}
+              isRequired
+            />
+          </div>
+          <div className="nypl-submit-button-wrapper">
+            <input
+              className="nypl-primary-button"
+              type="submit"
+              value="Submit"
+              disabled={this.props.isFormProcessing}
+            />
+          </div>
       </form>
     );
   }

--- a/src/shared/containers/Refile/RefileErrorsForm.jsx
+++ b/src/shared/containers/Refile/RefileErrorsForm.jsx
@@ -321,11 +321,21 @@ class RefileErrorsForm extends Component {
   * @desc Renders the results of refile errors
   */
   renderRefileErrorResults() {
-    let resultContent = '';
+    let resultContent = null;
 
+    // Renders the error instruction based on the response from the Node server
     if (this.state.formResult.response) {
-      resultContent = <p className="display-result-text">The input dates have invalid format or value, please check again.</p>;
-      return resultContent;
+      if (this.state.formResult.response.response.status === 400) {
+        resultContent = 'The input dates have invalid format or value, please check again.';
+      } else {
+        resultContent = 'Internal server error. Please check your credentials or try again later.';
+      }
+
+      return (
+        <p className="display-result-text">
+          {resultContent}
+        </p>
+      );
     }
 
     const itemRows = (this.state.refileErrorResults && this.state.refileErrorResults.length) ?

--- a/src/shared/routes/index.jsx
+++ b/src/shared/routes/index.jsx
@@ -9,6 +9,11 @@ const routes = [
     component: ApplicationContainer,
     routes: [
       {
+        path: '/',
+        exact: true,
+        component: UpdateMetadata
+      },
+      {
         path: '/transfer-metadata',
         exact: true,
         component: TransferMetadata


### PR DESCRIPTION
This PR integrates with NYPL design toolkit to give styles following our NYPL design pattern. Mainly, it gives the result table the styles to help the users read the information easier. It also hide the previous button or next button based on which page the user is on. Finally, it updates the date inputs from text type to date type.

This PR also solves part of the accessibility issues, however, using date input leads another issue to voice over that the inputs can't be read. A ticket will be created addressing on that. I will consult with Willa to see how I can fix it.

Can be test on dev here
http://nypl-recap-admin-dev.us-east-1.elasticbeanstalk.com/