### PR TITLE
Add two more columns for refile error display

### DIFF
--- a/src/client/styles/containers/_refile.scss
+++ b/src/client/styles/containers/_refile.scss
@@ -48,3 +48,9 @@
 .display-result-text {
   margin-top: 20px;
 }
+
+.af-message {
+  display: block;
+  padding-left: 20px;
+  text-align: left;
+}

--- a/src/shared/containers/Refile/RefileErrorsForm.jsx
+++ b/src/shared/containers/Refile/RefileErrorsForm.jsx
@@ -351,7 +351,7 @@ class RefileErrorsForm extends Component {
               <th className="barcode-th">{item.itemBarcode}</th>
               <td>{(item.updatedDate) ? item.createdDate.split('T')[0] : ''}</td>
               <td>{(item.updatedDate) ? item.updatedDate.split('T')[0] : ''}</td>
-              <td lassName="af-message-td">{afMessages}</td>
+              <td className="af-message-td">{afMessages}</td>
               <td></td>
             </tr>
           );

--- a/src/shared/containers/Refile/RefileErrorsForm.jsx
+++ b/src/shared/containers/Refile/RefileErrorsForm.jsx
@@ -345,6 +345,16 @@ class RefileErrorsForm extends Component {
         const afMessages = (afMessageArray.length) ?
           map(afMessageArray, (message, i) => <span className="af-message" key={i}>{message.replace(/^\"|\"$/g, '')}</span>): null;
 
+        let isNyplItem = 'yes';
+
+        const sip2Response = (item.sip2Response) ? JSON.parse(item.sip2Response) : null;
+        const CR = (sip2Response && sip2Response.variable.CR && sip2Response.variable.CR.length) ?
+          sip2Response.variable.CR[0].trim() :undefined;
+
+        if (CR == 'os') {
+          isNyplItem = 'no'
+        }
+
         return (
             <tr key={i}>
               <td>{item.id}</td>
@@ -352,7 +362,7 @@ class RefileErrorsForm extends Component {
               <td>{(item.updatedDate) ? item.createdDate.split('T')[0] : ''}</td>
               <td>{(item.updatedDate) ? item.updatedDate.split('T')[0] : ''}</td>
               <td className="af-message-td">{afMessages}</td>
-              <td></td>
+              <td>{isNyplItem}</td>
             </tr>
           );
         }

--- a/src/shared/containers/Refile/RefileErrorsForm.jsx
+++ b/src/shared/containers/Refile/RefileErrorsForm.jsx
@@ -188,11 +188,7 @@ class RefileErrorsForm extends Component {
       }, () => { this.handleFormSubmit(); });
     };
 
-    if (type === 'pre') {
-      setStateForPagination();
-    } else {
-      setStateForPagination();
-    }
+    setStateForPagination();
   }
 
   /**

--- a/src/shared/containers/Refile/RefileErrorsForm.jsx
+++ b/src/shared/containers/Refile/RefileErrorsForm.jsx
@@ -339,13 +339,23 @@ class RefileErrorsForm extends Component {
     }
 
     const itemRows = (this.state.refileErrorResults && this.state.refileErrorResults.length) ?
-      map(this.state.refileErrorResults, (item, i) =>
-        <tr key={i}>
-          <td>{item.id}</td>
-          <th className="barcode-th">{item.itemBarcode}</th>
-          <td>{(item.updatedDate) ? item.createdDate.split('T')[0] : ''}</td>
-          <td>{(item.updatedDate) ? item.updatedDate.split('T')[0] : ''}</td>
-        </tr>
+      map(this.state.refileErrorResults, (item, i) => {
+        const afMessageString = (item.afMessage) ? item.afMessage.replace(/^\[|\]$/g, '') : '';
+        const afMessageArray = (afMessageString) ? afMessageString.split(',') : '';
+        const afMessages = (afMessageArray.length) ?
+          map(afMessageArray, (message, i) => <span className="af-message" key={i}>{message.replace(/^\"|\"$/g, '')}</span>): null;
+
+        return (
+            <tr key={i}>
+              <td>{item.id}</td>
+              <th className="barcode-th">{item.itemBarcode}</th>
+              <td>{(item.updatedDate) ? item.createdDate.split('T')[0] : ''}</td>
+              <td>{(item.updatedDate) ? item.updatedDate.split('T')[0] : ''}</td>
+              <td lassName="af-message-td">{afMessages}</td>
+              <td></td>
+            </tr>
+          );
+        }
       ) : null;
 
     resultContent = (itemRows) ? (
@@ -357,6 +367,8 @@ class RefileErrorsForm extends Component {
             <th scope="col">Barcodes</th>
             <th scope="col">Created Date</th>
             <th scope="col">Updated Date</th>
+            <th scope="col">AF</th>
+            <th scope="col">NYPL Item?</th>
           </tr>
         </thead>
         <tbody className="result-table-body">

--- a/src/shared/containers/Refile/RefileErrorsForm.jsx
+++ b/src/shared/containers/Refile/RefileErrorsForm.jsx
@@ -2,9 +2,11 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import axios from 'axios';
 import isEmpty from 'lodash/isEmpty';
-import { forIn, map, assign } from 'lodash';
-import FormField from '../../components/FormField/FormField';
+import { forIn, assign } from 'lodash';
 import moment from 'moment';
+import FormField from '../../components/FormField/FormField';
+import { modelRefileErrorResponse } from './../../utils/modelRefileErrorDataUtils';
+
 
 class RefileErrorsForm extends Component {
   constructor(props) {
@@ -338,37 +340,9 @@ class RefileErrorsForm extends Component {
       );
     }
 
-    const itemRows = (this.state.refileErrorResults && this.state.refileErrorResults.length) ?
-      map(this.state.refileErrorResults, (item, i) => {
-        const afMessageString = (item.afMessage) ? item.afMessage.replace(/^\[|\]$/g, '') : '';
-        const afMessageArray = (afMessageString) ? afMessageString.split(',') : '';
-        const afMessages = (afMessageArray.length) ?
-          map(afMessageArray, (message, i) => <span className="af-message" key={i}>{message.replace(/^\"|\"$/g, '')}</span>): null;
+    const itemRows = modelRefileErrorResponse(this.state.refileErrorResults);
 
-        let isNyplItem = 'yes';
-
-        const sip2Response = (item.sip2Response) ? JSON.parse(item.sip2Response) : null;
-        const CR = (sip2Response && sip2Response.variable.CR && sip2Response.variable.CR.length) ?
-          sip2Response.variable.CR[0].trim() :undefined;
-
-        if (CR == 'os') {
-          isNyplItem = 'no'
-        }
-
-        return (
-            <tr key={i}>
-              <td>{item.id}</td>
-              <th className="barcode-th">{item.itemBarcode}</th>
-              <td>{(item.updatedDate) ? item.createdDate.split('T')[0] : ''}</td>
-              <td>{(item.updatedDate) ? item.updatedDate.split('T')[0] : ''}</td>
-              <td className="af-message-td">{afMessages}</td>
-              <td>{isNyplItem}</td>
-            </tr>
-          );
-        }
-      ) : null;
-
-    resultContent = (itemRows) ? (
+    resultContent = (itemRows.length) ? (
       <table className="result-table">
         <caption className="hidden">Refile Error Details</caption>
         <thead>
@@ -385,7 +359,10 @@ class RefileErrorsForm extends Component {
           {itemRows}
         </tbody>
       </table>
-    ) : <p className="display-result-text">There is no refile errors in the range of the selected dates.</p>;
+    ) :
+      <p className="display-result-text">
+        There is no refile errors in the range of the selected dates.
+      </p>;
 
     return resultContent;
   }
@@ -443,8 +420,9 @@ class RefileErrorsForm extends Component {
     const totalPageNumber = Math.ceil((parseInt(totalResultCount, 10) / 25));
     const displayFields = this.state.displayFields;
     const displayingText = (this.state.refileErrorResults && this.state.refileErrorResults.length) ?
-      <p className="display-result-text">Displaying {itemStart}-{itemEnd} of {totalResultCount} errors from {displayFields.startDate}-{displayFields.endDate}</p> :
-      null;
+      <p className="display-result-text">
+        Displaying {itemStart}-{itemEnd} of {totalResultCount} errors from {displayFields.startDate}-{displayFields.endDate}
+      </p> : null;
     const pageText = (this.state.refileErrorResults && this.state.refileErrorResults.length) ?
       <span className="page-count">Page {currentPage} of {totalPageNumber}</span> : null;
 

--- a/src/shared/utils/modelRefileErrorDataUtils.js
+++ b/src/shared/utils/modelRefileErrorDataUtils.js
@@ -1,0 +1,43 @@
+import { map } from 'lodash';
+import React from 'react';
+
+/**
+* @desc Renders the rows of the table to display refile errors.
+*/
+export function modelRefileErrorResponse(data) {
+  const modeledData = [];
+
+  if (data && data.length) {
+    map(data, (item, i) => {
+      const afMessageArray = (item.afMessage) ? JSON.parse(item.afMessage) : [];
+      const afMessages = (afMessageArray.length) ?
+        map(
+          afMessageArray,
+          (message, n) => <span className="af-message" key={n}>{message}</span>
+        ) : null;
+
+      let isNyplItem = 'yes';
+
+      const sip2Response = (item.sip2Response) ? JSON.parse(item.sip2Response) : null;
+      const CR = (sip2Response && sip2Response.variable.CR && sip2Response.variable.CR.length) ?
+        sip2Response.variable.CR[0].trim() : undefined;
+
+      if (CR === 'os') {
+        isNyplItem = 'no';
+      }
+
+      modeledData.push(
+        <tr key={i}>
+          <td>{item.id}</td>
+          <th className="barcode-th">{item.itemBarcode}</th>
+          <td>{(item.updatedDate) ? item.createdDate.split('T')[0] : ''}</td>
+          <td>{(item.updatedDate) ? item.updatedDate.split('T')[0] : ''}</td>
+          <td className="af-message-td">{afMessages}</td>
+          <td>{isNyplItem}</td>
+        </tr>
+      );
+    });
+  }
+
+  return modeledData;
+}


### PR DESCRIPTION
This PR adds two more columns to refile error table. Details could be found in this ticket:
https://jira.nypl.org/browse/SCC-385

Can be tested here
http://nypl-recap-admin-dev.us-east-1.elasticbeanstalk.com/